### PR TITLE
Expose the getCookie function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ yarn add react-use-cookie
 
 ## Usage
 
+This package has a few different exports.
+
+### `useCookie`
+
 ```jsx
 import useCookie from 'react-use-cookie';
 
@@ -33,7 +37,20 @@ export default (props) => {
 };
 ```
 
-You can also access a `getCookie` function, if you need to access cookies outside of a React-component:
+You can also specify an optional third argument - an options object with the following keys:
+
+```tsx
+{
+  // The number of days the cookie is stored (defaults to 7)
+  days: number;
+  // The path of the cookie (defaults to '/')
+  path: string;
+}
+```
+
+### `getCookie`
+
+If you need to access a cookie outside of a React component, you can use the named `getCookie` export:
 
 ```jsx
 import { getCookie } from 'react-use-cookie';
@@ -42,6 +59,28 @@ const getUser = () => {
   const xsrfToken = getCookie('XSRF-TOKEN');
   // use to call your API etc
 };
+```
+
+### `setCookie`
+
+If you need to set a cookie outside of a React component, you can use the named `setCookie` export:
+
+```jsx
+import { setCookie } from 'react-use-cookie';
+const saveLocale = (locale) => {
+  setCookie('locale', locale);
+};
+```
+
+You can also specify an optional third argument - the same options object as above:
+
+```tsx
+{
+  // The number of days the cookie is stored (defaults to 7)
+  days: number;
+  // The path of the cookie (defaults to '/')
+  path: string;
+}
 ```
 
 [npm-badge]: https://img.shields.io/npm/v/react-use-cookie.svg

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn add react-use-cookie
 ```jsx
 import useCookie from 'react-use-cookie';
 
-export default props => {
+export default (props) => {
   const [userToken, setUserToken] = useCookie('token', '0');
 
   render(
@@ -30,6 +30,17 @@ export default props => {
       <button onClick={() => setUserToken('123')}>Change token</button>
     </div>
   );
+};
+```
+
+You can also access a `getCookie` function, if you need to access cookies outside of a React-component:
+
+```jsx
+import { getCookie } from 'react-use-cookie';
+
+const getUser = () => {
+  const xsrfToken = getCookie('XSRF-TOKEN');
+  // use to call your API etc
 };
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,13 +4,19 @@
 
 declare module 'react-use-cookie' {
   interface cookieOptions {
-    days: number;
-    path: string;
+    days?: number;
+    path?: string;
   }
 
   export interface updateItem {
     (value: string, options?: cookieOptions): void;
   }
+
+  export function setCookie(
+    name: string,
+    value: string,
+    options?: cookieOptions
+  ): void;
 
   export function getCookie(name: string): string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,9 @@ declare module 'react-use-cookie' {
     (value: string, options?: cookieOptions): void;
   }
 
-  export default function(
+  export function getCookie(name: string): string;
+
+  export default function (
     key: string,
     initialValue: string
   ): [string, updateItem];

--- a/index.js
+++ b/index.js
@@ -12,14 +12,14 @@ const setCookie = (name, value, options) => {
     options.path;
 };
 
-const getCookie = name => {
+export const getCookie = (name) => {
   return document.cookie.split('; ').reduce((r, v) => {
     const parts = v.split('=');
     return parts[0] === name ? decodeURIComponent(parts[1]) : r;
   }, '');
 };
 
-export default function(key, initialValue) {
+export default function (key, initialValue) {
   const [item, setItem] = useState(() => {
     return getCookie(key) || initialValue;
   });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 
-const setCookie = (name, value, options) => {
-  const expires = new Date(Date.now() + options.days * 864e5).toUTCString();
+export const setCookie = (name, value, options) => {
+  const optionsWithDefaults = {
+    days: 7,
+    path: '/',
+    ...options,
+  };
+  const expires = new Date(
+    Date.now() + optionsWithDefaults.days * 864e5
+  ).toUTCString();
   document.cookie =
     name +
     '=' +
@@ -9,7 +16,7 @@ const setCookie = (name, value, options) => {
     '; expires=' +
     expires +
     '; path=' +
-    options.path;
+    optionsWithDefaults.path;
 };
 
 export const getCookie = (name) => {
@@ -24,7 +31,7 @@ export default function (key, initialValue) {
     return getCookie(key) || initialValue;
   });
 
-  const updateItem = (value, options = { days: 7, path: '/' }) => {
+  const updateItem = (value, options) => {
     setItem(value);
     setCookie(key, value, options);
   };


### PR DESCRIPTION
We have this API file, where we need to get an XSRF token from a cookie for each request. It's not a React component, so I can't use the hook to access the cookie.

For now I've just copied out the getCookie code into our own codebase, but it would be useful to export it from this package as well.