### PR TITLE
Add support for React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.7",


### PR DESCRIPTION
That just add support for React 17

There could be another option to specify dependencies like:
```
'react': '^16.8.0 || ^17'
```

But many other libraries prefer to specify it as `>=16.8.0`, so I think it is good enough.
Let me know if something more needed.

#24