### PR TITLE
Add useCallback for the updateItem of the default function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const isBrowser = typeof window !== 'undefined';
 
@@ -56,10 +56,10 @@ export default function (key, initialValue) {
     return getCookie(key, initialValue);
   });
 
-  const updateItem = (value, options) => {
+  const updateItem = useCallback((value, options) => {
     setItem(value);
     setCookie(key, value, options);
-  };
+  }, [key]);
 
   return [item, updateItem];
 }


### PR DESCRIPTION
Wraps the `updateItem` funciton in a `useCallback`.

This is so that `updateItem` can be added to the dependency array of an effect, but not trigger the effect every render.